### PR TITLE
Update YQ_VERSION to 4.49.2-r6

### DIFF
--- a/cloudflared/Dockerfile
+++ b/cloudflared/Dockerfile
@@ -9,7 +9,7 @@ ENV S6_STAGE2_HOOK="/etc/s6-overlay/s6-rc.d/caddy/condition_caddy.sh"
 ARG BUILD_ARCH="amd64"
 
 # renovate: datasource=repology depName=yq packageName=alpine_3_22/yq-go versioning=loose
-ARG YQ_VERSION="4.49.2-r5"
+ARG YQ_VERSION="4.49.2-r6"
 # renovate: datasource=github-releases depName=cloudflared packageName=cloudflare/cloudflared versioning=loose
 ARG CLOUDFLARED_VERSION="2026.5.0"
 


### PR DESCRIPTION
because yq-go=4.49.2-r5 is no longer available in Alpine.

# Proposed Changes

> (Describe the changes and rationale behind them)

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
